### PR TITLE
Add to_xml_str utility function and tests

### DIFF
--- a/languru/utils/xml.py
+++ b/languru/utils/xml.py
@@ -1,0 +1,88 @@
+import json
+from typing import Any, Dict, Optional, Sequence, Text, Union, cast
+from xml.dom.minidom import DOMImplementation, getDOMImplementation
+
+from pydantic import BaseModel
+
+
+def to_xml_str(
+    items: Union[Sequence[Dict[Text, Any]], Sequence["BaseModel"]],
+    attributes_keys: Optional[Sequence[Text]] = None,
+    content_key: Optional[Text] = None,
+    element_name: Text = "item",
+    root_name: Text = "items",
+    indent: Text = "",
+    remove_xml_declaration: bool = True,
+) -> Text:
+    """Convert a list of items to XML string.
+
+    Parameters
+    ----------
+    items : Union[Sequence[Dict[Text, Any]], Sequence["BaseModel"]]
+        List of items to convert.
+    attributes_keys : Optional[Sequence[Text]], optional
+        List of keys to use as attributes, by default None.
+    content_key : Optional[Text], optional
+        Key to use as content, by default None.
+    element_name : Text, optional
+        Name of the element, by default "item".
+    root_name : Text, optional
+        Name of the root element, by default "items".
+    indent : Text, optional
+        Indentation, by default "".
+    remove_xml_declaration : bool, optional
+        Whether to remove XML declaration, by default True.
+
+    Returns
+    -------
+    Text
+        XML string.
+
+    Examples
+    --------
+    >>> items = [
+    ...     {"id": 1, "name": "item1"},
+    ...     {"id": 2, "name": "item2"},
+    ...     {"id": 3, "name": "item3"},
+    ... ]
+    >>> xml_str = to_xml_str(items, attributes_keys=["id"], content_key="name")
+    >>> print(xml_str)
+    <items>
+    <item id="1">item1</item>
+    <item id="2">item2</item>
+    <item id="3">item3</item>
+    </items>
+    """
+
+    dom_impl = getDOMImplementation()
+    dom_impl = cast(DOMImplementation, dom_impl)
+    doc = dom_impl.createDocument(None, root_name, None)
+    root = doc.documentElement
+
+    for item in items:
+        # Format data
+        item_dict = (
+            json.loads(item.model_dump_json())
+            if isinstance(item, BaseModel)
+            else dict(item)
+        )
+        # Create element
+        item_ele = doc.createElement(element_name)
+        # Add attributes
+        for attributes_key in attributes_keys or []:
+            if attributes_key in item_dict:
+                item_ele.setAttribute(attributes_key, str(item_dict[attributes_key]))
+        # Add content
+        if content_key is not None:
+            if content_key in item_dict:
+                item_ele.appendChild(doc.createTextNode(str(item_dict[content_key])))
+        root.appendChild(item_ele)
+
+    # Return XML string
+    out = doc.toprettyxml(indent=indent).strip()
+    if remove_xml_declaration is True:
+        # Remove (<?xml version="1.0" ?>)
+        xml_version, out_prune = out.split("\n", 1)
+        if xml_version.startswith("<?xml"):
+            out = out_prune.strip()
+    return out

--- a/tests/utils/test_xml.py
+++ b/tests/utils/test_xml.py
@@ -1,0 +1,91 @@
+from textwrap import dedent
+from typing import Dict, Text
+
+import pytest
+from pydantic import BaseModel
+
+from languru.utils.xml import to_xml_str
+
+
+class Item(BaseModel):
+    id: int
+    name: Text
+    type: Text
+
+
+simple_items = [
+    {"id": 1, "name": "item1"},
+    {"id": 2, "name": "item2"},
+    {"id": 3, "name": "item3"},
+]
+simple_items_xml = dedent(
+    """
+    <items>
+    <item id="1">item1</item>
+    <item id="2">item2</item>
+    <item id="3">item3</item>
+    </items>
+    """
+).strip()
+extra_items = [
+    {"id": 1, "name": "Allen", "type": "employee"},
+    {"id": 2, "name": "Alice", "type": "employee"},
+    {"id": 3, "name": "Alex", "type": "manager"},
+]
+extra_items_xml = dedent(
+    """
+    <users>
+        <user id="1" type="employee">Allen</user>
+        <user id="2" type="employee">Alice</user>
+        <user id="3" type="manager">Alex</user>
+    </users>
+    """
+).strip()
+model_items = [
+    Item(id=1, name="Allen", type="employee"),
+    Item(id=3, name="Alex", type="manager"),
+]
+model_items_xml = dedent(
+    """
+    <users>
+    <user id="1" type="employee">Allen</user>
+    <user id="3" type="manager">Alex</user>
+    </users>
+    """
+).strip()
+
+
+@pytest.mark.parametrize(
+    "items, parameters, expected_xml_str",
+    [
+        (
+            simple_items,
+            {"attributes_keys": ["id"], "content_key": "name"},
+            simple_items_xml,
+        ),
+        (
+            extra_items,
+            {
+                "attributes_keys": ["id", "type"],
+                "content_key": "name",
+                "element_name": "user",
+                "root_name": "users",
+                "indent": "    ",
+            },
+            extra_items_xml,
+        ),
+        (
+            model_items,
+            {
+                "attributes_keys": ["id", "type"],
+                "content_key": "name",
+                "element_name": "user",
+                "root_name": "users",
+            },
+            model_items_xml,
+        ),
+    ],
+)
+def test_to_xml_str(items, parameters: Dict, expected_xml_str: Text):
+    xml_str = to_xml_str(items, **parameters)
+    assert xml_str == expected_xml_str


### PR DESCRIPTION
- Add to_xml_str function in languru/utils/xml.py to convert a list of items (dicts or Pydantic models) to an XML string
- Add tests for to_xml_str in tests/utils/test_xml.py covering simple items, items with extra attributes, and Pydantic model items