### PR TITLE
Feature/openai plugins pplx

### DIFF
--- a/languru/openai_plugins/clients/pplx.py
+++ b/languru/openai_plugins/clients/pplx.py
@@ -1,0 +1,98 @@
+import os
+import time
+from typing import Optional, Text
+
+import httpx
+import openai
+from openai import OpenAI
+from openai import resources as OpenAIResources
+from openai._types import NOT_GIVEN, Body, Headers, NotGiven, Query
+from openai.pagination import SyncPage
+from openai.types.model import Model
+
+from languru.openai_plugins.clients.utils import openai_init_parameter_keys
+
+
+class PerplexityModels(OpenAIResources.Models):
+
+    supported_models = frozenset(
+        [
+            "llama-3-sonar-small-32k-chat",
+            "llama-3-sonar-small-32k-online",
+            "llama-3-sonar-large-32k-chat",
+            "llama-3-sonar-large-32k-online",
+            "llama-3-8b-instruct",
+            "llama-3-70b-instruct",
+            "mixtral-8x7b-instruct",
+        ]
+    )
+
+    def retrieve(
+        self,
+        model: str,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        **kwargs,
+    ) -> "Model":
+        if model in self.supported_models:
+            return Model.model_validate(
+                {
+                    "id": model,
+                    "created": int(time.time()),
+                    "object": "model",
+                    "owned_by": "perplexity",
+                }
+            )
+        else:
+            error_message = (
+                f"Model {model} not found. Supported models are {self.supported_models}"
+            )
+            raise openai.NotFoundError(
+                error_message,
+                response=httpx.Response(status_code=404, text=error_message),
+                body=None,
+            )
+
+    def list(
+        self,
+        *,
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        **kwargs,
+    ) -> "SyncPage[Model]":
+        created = int(time.time())
+        models = [
+            Model.model_validate(
+                {
+                    "id": model,
+                    "created": created,
+                    "object": "model",
+                    "owned_by": "perplexity",
+                }
+            )
+            for model in self.supported_models
+        ]
+        return SyncPage(data=models, object="list")
+
+
+class PerplexityOpenAI(OpenAI):
+    models: PerplexityModels
+
+    def __init__(self, *, api_key: Optional[Text] = None, **kwargs):
+        api_key = (
+            api_key or os.getenv("PPLX_API_KEY") or os.getenv("PERPLEXITY_API_KEY")
+        )
+        if not api_key:
+            raise ValueError("Perplexity API key is not provided")
+        kwargs["api_key"] = api_key
+        kwargs["base_url"] = "https://api.perplexity.ai"
+        kwargs = {k: v for k, v in kwargs.items() if k in openai_init_parameter_keys}
+
+        super().__init__(**kwargs)
+
+        self.models = PerplexityModels(self)

--- a/languru/openai_plugins/clients/pplx.py
+++ b/languru/openai_plugins/clients/pplx.py
@@ -26,6 +26,7 @@ class PerplexityModels(OpenAIResources.Models):
             "mixtral-8x7b-instruct",
         ]
     )
+    temperature_span = (0.0, 1.99)
 
     def retrieve(
         self,

--- a/tests/openai_plugins/test_pplx_openai.py
+++ b/tests/openai_plugins/test_pplx_openai.py
@@ -1,0 +1,18 @@
+from languru.openai_plugins.clients.pplx import PerplexityOpenAI
+
+test_chat_model_name = "llama-3-sonar-small-32k-chat"
+
+
+pplx_openai = PerplexityOpenAI()
+
+
+def test_google_openai_models_retrieve():
+    model = pplx_openai.models.retrieve(model=test_chat_model_name)
+    assert model.id == test_chat_model_name
+
+
+def test_google_openai_models_list():
+    model_res = pplx_openai.models.list()
+    assert len(model_res.data) > 0 and any(
+        [m.id == test_chat_model_name for m in model_res.data]
+    )

--- a/tests/openai_plugins/test_pplx_openai.py
+++ b/tests/openai_plugins/test_pplx_openai.py
@@ -1,9 +1,43 @@
 from languru.openai_plugins.clients.pplx import PerplexityOpenAI
+from languru.utils.prompt import ensure_chat_completion_message_params
 
-test_chat_model_name = "llama-3-sonar-small-32k-chat"
+test_chat_model_name = "llama-3-8b-instruct"
 
 
 pplx_openai = PerplexityOpenAI()
+
+
+def test_google_openai_chat_completions_create():
+    chat_res = pplx_openai.chat.completions.create(
+        messages=ensure_chat_completion_message_params(
+            [
+                {"role": "system", "content": "Respond simple and concise."},
+                {"role": "user", "content": "Say Hi!"},
+            ]
+        ),
+        model=test_chat_model_name,
+        temperature=1.99,
+    )
+    assert chat_res.choices and chat_res.choices[0].message
+
+
+def test_google_openai_chat_completions_create_stream():
+    chat_stream = pplx_openai.chat.completions.create(
+        messages=ensure_chat_completion_message_params(
+            [
+                {"role": "system", "content": "Respond simple and concise."},
+                {"role": "user", "content": "Say Hi!"},
+            ]
+        ),
+        model=test_chat_model_name,
+        temperature=0.0,
+        stream=True,
+    )
+    for chunk in chat_stream:
+        if chunk.choices[0].finish_reason == "stop":
+            pass
+        else:
+            assert chunk.choices and chunk.choices[0].delta.content
 
 
 def test_google_openai_models_retrieve():


### PR DESCRIPTION
## New Perplexity OpenAI Client

A new `PerplexityOpenAI` client has been added in `languru/openai_plugins/clients/pplx.py`. This client:

- Inherits from the base `OpenAI` client
- Initializes with a Perplexity API key from the `PPLX_API_KEY` or `PERPLEXITY_API_KEY` environment variable
- Sets the base URL to `https://api.perplexity.ai`
- Supports a specific set of Perplexity models via the `PerplexityModels` resource

## Perplexity Models Resource

The `PerplexityModels` resource in `languru/openai_plugins/clients/pplx.py`:

- Inherits from `OpenAIResources.Models`
- Defines a set of supported Perplexity models
- Implements `retrieve` and `list` methods to return `Model` objects for the supported Perplexity models
- Raises a `NotFoundError` for unsupported models in the `retrieve` method

## Tests for the Perplexity OpenAI Client

Test cases have been added in `tests/openai_plugins/test_pplx_openai.py` to cover:

- Creating chat completions with the `llama-3-8b-instruct` model
- Creating chat completion streams with the `llama-3-8b-instruct` model
- Retrieving a specific Perplexity model
- Listing available Perplexity models

These tests ensure the basic functionality of the new `PerplexityOpenAI` client and its associated `PerplexityModels` resource.