### PR TITLE
### Update Model Names to Version 3.1

### DIFF
--- a/languru/examples/openapi/chat.py
+++ b/languru/examples/openapi/chat.py
@@ -58,7 +58,7 @@ chat_perplexity = {
     "summary": "Perplexity Online",
     "description": "Chat completion request",
     "value": {
-        "model": "llama-3-sonar-small-32k-online",
+        "model": "llama-3.1-sonar-small-128k-chat",
         "messages": [
             {"role": "system", "content": "Respond accurately and concisely."},
             {"role": "user", "content": "Why is the apple red?"},

--- a/languru/types/models.py
+++ b/languru/types/models.py
@@ -66,13 +66,13 @@ MODELS_GROQ = (
     "whisper-large-v3",
 )
 MODELS_PERPLEXITY = (
-    "llama-3-sonar-small-32k-chat",
-    "llama-3-sonar-small-32k-online",
-    "llama-3-sonar-large-32k-chat",
-    "llama-3-sonar-large-32k-online",
-    "llama-3-8b-instruct",
-    "llama-3-70b-instruct",
-    "mixtral-8x7b-instruct",
+    "llama-3.1-sonar-small-128k-online",
+    "llama-3.1-sonar-large-128k-online",
+    "llama-3.1-sonar-huge-128k-online",
+    "llama-3.1-sonar-small-128k-chat",
+    "llama-3.1-sonar-large-128k-chat",
+    "llama-3.1-8b-instruct",
+    "llama-3.1-70b-instruct",
 )
 MODELS_VOYAGE = (
     "voyage-large-2-instruct",

--- a/tests/openai_plugins/test_pplx_openai.py
+++ b/tests/openai_plugins/test_pplx_openai.py
@@ -1,7 +1,7 @@
 from languru.openai_plugins.clients.pplx import PerplexityOpenAI
 from languru.utils.openai_utils import ensure_chat_completion_message_params
 
-test_chat_model_name = "llama-3-8b-instruct"
+test_chat_model_name = "llama-3.1-sonar-small-128k-chat"
 
 
 pplx_openai = PerplexityOpenAI()

--- a/tests/prompts/test_prompt_template.py
+++ b/tests/prompts/test_prompt_template.py
@@ -4,7 +4,7 @@ from languru.openai_plugins.clients.pplx import PerplexityOpenAI
 from languru.prompts import PromptTemplate
 
 client = PerplexityOpenAI()
-model = "llama-3-sonar-small-32k-chat"
+model = "llama-3.1-sonar-small-128k-chat"
 
 
 def test_prompt_template_from_description():


### PR DESCRIPTION
- **chat.py**: Updated the model name from `llama-3-sonar-small-32k-online` to `llama-3.1-sonar-small-128k-chat` for chat completion requests.

- **models.py**: Revised the `MODELS_PERPLEXITY` list to include new model names:
  - Replaced old models with updated versions, including `llama-3.1-sonar-small-128k-chat` and others.

- **test_pplx_openai.py**: Changed the test model name to `llama-3.1-sonar-small-128k-chat` to align with the updated model specifications.

- **test_prompt_template.py**: Updated the model variable to `llama-3.1-sonar-small-128k-chat` for consistency in tests.